### PR TITLE
[ODIN-321] data types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -81,6 +81,7 @@
     "tuple": "cpp",
     "typeinfo": "cpp",
     "filesystem": "cpp",
-    "__functional_03": "cpp"
+    "__functional_03": "cpp",
+    "__memory": "cpp"
   }
 }

--- a/addon/result_iterator.cc
+++ b/addon/result_iterator.cc
@@ -159,9 +159,13 @@ namespace NodeDuckDB {
       case duckdb::LogicalTypeId::DECIMAL:
         return  Napi::Number::New(env, val.CastAs(duckdb::LogicalType::DOUBLE).GetValue<double>());
       case duckdb::LogicalTypeId::VARCHAR:
-      case duckdb::LogicalTypeId::BLOB:
         return  Napi::String::New(env, val.GetValue<string>());
-
+      case duckdb::LogicalTypeId::BLOB: {
+        int array_length = val.str_value.length();
+        char char_array[array_length + 1];
+        strcpy(char_array, val.str_value.c_str());
+        return  Napi::Buffer<char>::Copy(env, char_array, array_length);
+      }
       case duckdb::LogicalTypeId::TIMESTAMP: {
         if (result->types[col_idx].InternalType() != duckdb::PhysicalType::INT64) {
           throw runtime_error("expected int64 for timestamp");

--- a/addon/result_iterator.cc
+++ b/addon/result_iterator.cc
@@ -125,7 +125,6 @@ namespace NodeDuckDB {
 
     for (idx_t col_idx = 0; col_idx < col_count; col_idx++) {
       auto cellValue = getCellValue(env, col_idx);
-      cout << result->names[col_idx] << endl;
       row.Set(result->names[col_idx], cellValue);
     }
     return row;
@@ -188,7 +187,8 @@ namespace NodeDuckDB {
         return  Napi::String::New(env, val.ToString());
       }
       default:
-        throw runtime_error("unsupported type: " + result->types[col_idx].ToString());
+        // default to getting string representation
+        return Napi::String::New(env, val.ToString());
       }
   }
 }

--- a/addon/result_iterator.cc
+++ b/addon/result_iterator.cc
@@ -125,6 +125,7 @@ namespace NodeDuckDB {
 
     for (idx_t col_idx = 0; col_idx < col_count; col_idx++) {
       auto cellValue = getCellValue(env, col_idx);
+      cout << result->names[col_idx] << endl;
       row.Set(result->names[col_idx], cellValue);
     }
     return row;
@@ -147,6 +148,7 @@ namespace NodeDuckDB {
       case duckdb::LogicalTypeId::INTEGER:
         return  Napi::Number::New(env, val.GetValue<int32_t>());
       case duckdb::LogicalTypeId::BIGINT:
+      case duckdb::LogicalTypeId::HUGEINT:
         #ifdef NAPI_EXPERIMENTAL
           return  Napi::BigInt::New(env, val.GetValue<int64_t>());
         #else

--- a/addon/result_iterator.cc
+++ b/addon/result_iterator.cc
@@ -151,11 +151,10 @@ namespace NodeDuckDB {
         return  Napi::BigInt::New(env, val.GetValue<int64_t>());
       case duckdb::LogicalTypeId::HUGEINT: {
         auto huge_int = val.GetValue<duckdb::hugeint_t>();
-        int negative = huge_int.upper < 0;
-        uint64_t upper = (uint64_t)huge_int.upper;
-
-        uint64_t arr[2] {huge_int.lower, upper};
-        return  Napi::BigInt::New(env, negative, 2, &arr[0]);
+        int is_negative = huge_int.upper < 0;
+        duckdb::hugeint_t positive_huge_int = is_negative ? huge_int * duckdb::hugeint_t(-1) : huge_int;
+        uint64_t arr[2] {positive_huge_int.lower, (uint64_t)positive_huge_int.upper};        
+        return  Napi::BigInt::New(env, is_negative, 2, &arr[0]);
       }
       case duckdb::LogicalTypeId::FLOAT:
         return  Napi::Number::New(env, val.GetValue<float>());

--- a/addon/result_iterator.cc
+++ b/addon/result_iterator.cc
@@ -161,6 +161,7 @@ namespace NodeDuckDB {
       case duckdb::LogicalTypeId::DECIMAL:
         return  Napi::Number::New(env, val.CastAs(duckdb::LogicalType::DOUBLE).GetValue<double>());
       case duckdb::LogicalTypeId::VARCHAR:
+      case duckdb::LogicalTypeId::BLOB:
         return  Napi::String::New(env, val.GetValue<string>());
 
       case duckdb::LogicalTypeId::TIMESTAMP: {

--- a/addon/result_iterator.cc
+++ b/addon/result_iterator.cc
@@ -150,6 +150,9 @@ namespace NodeDuckDB {
       case duckdb::LogicalTypeId::BIGINT:
         return  Napi::BigInt::New(env, val.GetValue<int64_t>());
       case duckdb::LogicalTypeId::HUGEINT: {
+        // hugeint_t represents a signed 128 bit integer in two's complement notation
+        // napi's BigInt is basically a regular signed integer (MSB)
+        // so we want to make sure we pass the absolute value of the huge int into napi plus the sign bit
         auto huge_int = val.GetValue<duckdb::hugeint_t>();
         int is_negative = huge_int.upper < 0;
         duckdb::hugeint_t positive_huge_int = is_negative ? huge_int * duckdb::hugeint_t(-1) : huge_int;
@@ -167,6 +170,7 @@ namespace NodeDuckDB {
       case duckdb::LogicalTypeId::BLOB: {
         int array_length = val.str_value.length();
         char char_array[array_length + 1];
+        // TODO: multiple copies, improve
         strcpy(char_array, val.str_value.c_str());
         return  Napi::Buffer<char>::Copy(env, char_array, array_length);
       }

--- a/addon/result_iterator.cc
+++ b/addon/result_iterator.cc
@@ -182,7 +182,7 @@ namespace NodeDuckDB {
         if (result->types[col_idx].InternalType() != duckdb::PhysicalType::INT32) {
           throw runtime_error("expected int32 for time");
         }
-        int64_t tval = val.GetValue<int64_t>();      
+        int64_t tval = val.GetValue<int32_t>();      
         return  Napi::Number::New(env, GetTime(tval));
       }
 

--- a/addon/result_iterator.cc
+++ b/addon/result_iterator.cc
@@ -147,7 +147,8 @@ namespace NodeDuckDB {
       case duckdb::LogicalTypeId::INTEGER:
         return  Napi::Number::New(env, val.GetValue<int32_t>());
       case duckdb::LogicalTypeId::BIGINT:
-        return  Napi::Number::New(env, val.GetValue<int64_t>());
+        // for now return as string: BigInt is supported by Napi v5+
+        return  Napi::String::New(env, val.ToString());
       case duckdb::LogicalTypeId::HUGEINT:
         // for now return as string: BigInt is supported by Napi v5+
         return  Napi::String::New(env, val.ToString());

--- a/addon/result_iterator.cc
+++ b/addon/result_iterator.cc
@@ -148,12 +148,10 @@ namespace NodeDuckDB {
       case duckdb::LogicalTypeId::INTEGER:
         return  Napi::Number::New(env, val.GetValue<int32_t>());
       case duckdb::LogicalTypeId::BIGINT:
+        return  Napi::Number::New(env, val.GetValue<int64_t>());
       case duckdb::LogicalTypeId::HUGEINT:
-        #ifdef NAPI_EXPERIMENTAL
-          return  Napi::BigInt::New(env, val.GetValue<int64_t>());
-        #else
-          return  Napi::Number::New(env, val.GetValue<int64_t>());
-        #endif
+        // for now return as string: BigInt is supported by Napi v5+
+        return  Napi::String::New(env, val.ToString());
       case duckdb::LogicalTypeId::FLOAT:
         return  Napi::Number::New(env, val.GetValue<float>());
       case duckdb::LogicalTypeId::DOUBLE:

--- a/addon/result_iterator.cc
+++ b/addon/result_iterator.cc
@@ -186,7 +186,9 @@ namespace NodeDuckDB {
         int64_t tval = val.GetValue<int32_t>();      
         return  Napi::Number::New(env, GetTime(tval));
       }
-
+      case duckdb::LogicalTypeId::INTERVAL: {
+        return  Napi::String::New(env, val.ToString());
+      }
       default:
         throw runtime_error("unsupported type: " + result->types[col_idx].ToString());
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepcrawl/node-duckdb",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "private": false,
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepcrawl/node-duckdb",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "private": false,
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "yarn build:duckdb && yarn build:addon && yarn build:ts",
-    "build:addon": "rimraf build && cmake-js compile --CDnapi_build_version=4",
+    "build:addon": "rimraf build && cmake-js compile --CDnapi_build_version=6",
     "build:duckdb": "cd duckdb && make && cd -",
     "build:test:watch": "nodemon --exec 'yarn build && yarn jest --testTimeout=60000'",
     "build:ts": "rimraf dist && ttsc",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "types": "dist/index.d.ts",
   "binary": {
     "napi_versions": [
-      4
+      6
     ]
   },
   "scripts": {

--- a/src/addon-bindings/connection-binding.ts
+++ b/src/addon-bindings/connection-binding.ts
@@ -5,7 +5,7 @@ import { IExecuteOptions } from "@addon-types";
  */
 
 import { DuckDBBinding } from "./duckdb-binding";
-import { ResultIteratorBinding } from "./result-iterator-binding";
+import { ResultIteratorClass } from "./result-iterator-binding";
 
 // lambda doesn't work with npm module bindings
 // eslint-disable-next-line node/no-unpublished-require, @typescript-eslint/no-var-requires
@@ -13,7 +13,7 @@ const { Connection } = require("../../build/Release/node-duckdb-addon.node");
 
 export declare class ConnectionClass {
   constructor(db: InstanceType<typeof DuckDBBinding>);
-  public execute(command: string, options?: IExecuteOptions): Promise<InstanceType<typeof ResultIteratorBinding>>;
+  public execute<T>(command: string, options?: IExecuteOptions): Promise<ResultIteratorClass<T>>;
   public close(): void;
   public isClosed: boolean;
 }

--- a/src/addon-bindings/result-iterator-binding.ts
+++ b/src/addon-bindings/result-iterator-binding.ts
@@ -8,7 +8,7 @@ const { ResultIterator } = require("../../build/Release/node-duckdb-addon.node")
  */
 
 export declare class ResultIteratorClass {
-  public fetchRow(): unknown | unknown[];
+  public fetchRow<T>(): T;
   public describe(): string[][];
   public close(): void;
   public type: ResultType;

--- a/src/addon-bindings/result-iterator-binding.ts
+++ b/src/addon-bindings/result-iterator-binding.ts
@@ -7,8 +7,8 @@ const { ResultIterator } = require("../../build/Release/node-duckdb-addon.node")
  * Bindings should not be used directly, only through the addon wrappers
  */
 
-export declare class ResultIteratorClass {
-  public fetchRow<T>(): T;
+export declare class ResultIteratorClass<T> {
+  public fetchRow(): T;
   public describe(): string[][];
   public close(): void;
   public type: ResultType;

--- a/src/addon/connection.ts
+++ b/src/addon/connection.ts
@@ -7,12 +7,12 @@ import { IExecuteOptions } from "@addon-types";
 export class Connection {
   constructor(private duckdb: DuckDB) {}
   private connectionBinding = new ConnectionBinding(this.duckdb.db);
-  public async execute(command: string, options?: IExecuteOptions): Promise<ResultStream> {
-    const resultIteratorBinding = await this.connectionBinding.execute(command, options);
+  public async execute<T>(command: string, options?: IExecuteOptions): Promise<ResultStream<T>> {
+    const resultIteratorBinding = await this.connectionBinding.execute<T>(command, options);
     return new ResultStream(new ResultIterator(resultIteratorBinding));
   }
-  public async executeIterator(command: string, options?: IExecuteOptions): Promise<ResultIterator> {
-    return new ResultIterator(await this.connectionBinding.execute(command, options));
+  public async executeIterator<T>(command: string, options?: IExecuteOptions): Promise<ResultIterator<T>> {
+    return new ResultIterator(await this.connectionBinding.execute<T>(command, options));
   }
   public close(): void {
     return this.connectionBinding.close();

--- a/src/addon/result-iterator.ts
+++ b/src/addon/result-iterator.ts
@@ -1,14 +1,14 @@
 import { ResultType } from "@addon-types";
 import { ResultIteratorClass } from "../addon-bindings";
 
-export class ResultIterator {
-    constructor(private resultInterator: ResultIteratorClass) {}
-    public fetchRow<T>(): T {
-        return this.resultInterator.fetchRow<T>();
+export class ResultIterator<T> {
+    constructor(private resultInterator: ResultIteratorClass<T>) {}
+    public fetchRow(): T {
+        return this.resultInterator.fetchRow();
     }
-    public fetchAllRows<T>(): T[] {
+    public fetchAllRows(): T[] {
         const allRows: T[] = [];
-        for (let element = this.fetchRow<T>(); element !== null; element = this.fetchRow<T>()) {
+        for (let element = this.fetchRow(); element !== null; element = this.fetchRow()) {
             allRows.push(element);
           }
         return allRows;

--- a/src/addon/result-iterator.ts
+++ b/src/addon/result-iterator.ts
@@ -3,12 +3,12 @@ import { ResultIteratorClass } from "../addon-bindings";
 
 export class ResultIterator {
     constructor(private resultInterator: ResultIteratorClass) {}
-    public fetchRow(): unknown | unknown[] {
-        return this.resultInterator.fetchRow();
+    public fetchRow<T>(): T {
+        return this.resultInterator.fetchRow<T>();
     }
-    public fetchAllRows(): unknown[] | unknown[][] {
-        const allRows = [];
-        for (let element = this.fetchRow(); element !== null; element = this.fetchRow()) {
+    public fetchAllRows<T>(): T[] {
+        const allRows: T[] = [];
+        for (let element = this.fetchRow<T>(); element !== null; element = this.fetchRow<T>()) {
             allRows.push(element);
           }
         return allRows;

--- a/src/addon/result-stream.ts
+++ b/src/addon/result-stream.ts
@@ -2,8 +2,8 @@ import { Readable } from "stream";
 
 import { ResultIterator } from "./result-iterator";
 
-export class ResultStream extends Readable {
-  constructor(private resultIterator: ResultIterator) {
+export class ResultStream<T> extends Readable {
+  constructor(private resultIterator: ResultIterator<T>) {
     super({ objectMode: true });
   }
 

--- a/src/tests/async.test.ts
+++ b/src/tests/async.test.ts
@@ -19,7 +19,7 @@ const expectedResult1 = [
   3,
   4,
 ];
-const expectedResult2 = [60];
+const expectedResult2 = ["60"];
 
 const executeOptions: IExecuteOptions = { forceMaterialized: true, rowResultFormat: RowResultFormat.Array };
 

--- a/src/tests/async.test.ts
+++ b/src/tests/async.test.ts
@@ -19,7 +19,7 @@ const expectedResult1 = [
   3,
   4,
 ];
-const expectedResult2 = ["60"];
+const expectedResult2 = [60n];
 
 const executeOptions: IExecuteOptions = { forceMaterialized: true, rowResultFormat: RowResultFormat.Array };
 

--- a/src/tests/csv.test.ts
+++ b/src/tests/csv.test.ts
@@ -21,7 +21,7 @@ describe("executeIterator on csv", () => {
       "SELECT count(*) FROM read_csv_auto('src/tests/test-fixtures/web_page.csv')",
       executeOptions,
     );
-    expect(result.fetchRow()).toMatchObject(["60"]);
+    expect(result.fetchRow()).toMatchObject([60n]);
     expect(result.fetchRow()).toBe(null);
   });
 

--- a/src/tests/csv.test.ts
+++ b/src/tests/csv.test.ts
@@ -21,7 +21,7 @@ describe("executeIterator on csv", () => {
       "SELECT count(*) FROM read_csv_auto('src/tests/test-fixtures/web_page.csv')",
       executeOptions,
     );
-    expect(result.fetchRow()).toMatchObject([60]);
+    expect(result.fetchRow()).toMatchObject(["60"]);
     expect(result.fetchRow()).toBe(null);
   });
 

--- a/src/tests/data-types.test.ts
+++ b/src/tests/data-types.test.ts
@@ -114,12 +114,16 @@ describe("Data type mapping", () => {
     expect(result.fetchRow()).toMatchObject([1 + 1000 + 60000 + 60000 * 60]);
   });
 
-  // TODO: use typed arrays or blobs?
   it("supports BLOB", async () => {
-    const result = await connection.executeIterator(`SELECT CAST('\\x3131' AS BLOB)`, {
+    const result = await connection.executeIterator(`SELECT 'AB'::BLOB;`, {
       rowResultFormat: RowResultFormat.Array,
     });
-    expect(result.fetchRow()).toMatchObject(["\\x3131"]);
+    const resultBuffer = result.fetchRow<Buffer[]>()[0];
+    const view = new Int8Array(resultBuffer);
+    // ASCII "a"
+    expect(view[0]).toBe(65);
+    // ASCII "b"
+    expect(view[1]).toBe(66);
   });
 
   // TODO: either create a JS/TS object representing an interval or possibly convert to number

--- a/src/tests/data-types.test.ts
+++ b/src/tests/data-types.test.ts
@@ -47,7 +47,7 @@ describe("Data type mapping", () => {
 
   // TODO: possibly return as BigInt (napi v5+)
   it("supports BIGINT", async () => {
-    const bigInt = "9223372036854775807";
+    const bigInt = 9223372036854775807n;
 
     const result = await connection.executeIterator(`SELECT CAST (${bigInt} AS BIGINT)`, {
       rowResultFormat: RowResultFormat.Array,
@@ -57,8 +57,28 @@ describe("Data type mapping", () => {
   });
 
   // TODO: possibly return as BigInt (napi v5+)
+  it.only("supports HUGEINT - positive max", async () => {
+    const hugeInt = 170141183460469231731687303715884105727n;
+    const result = await connection.executeIterator(`SELECT CAST (${hugeInt} AS HUGEINT)`, {
+      rowResultFormat: RowResultFormat.Array,
+    });
+    const resultValue = (<number[]>result.fetchRow())[0];
+    expect(resultValue).toEqual(hugeInt);
+  });
+
+  // TODO: possibly return as BigInt (napi v5+)
+  it("supports HUGEINT - regular number", async () => {
+    const hugeInt = 132142n;
+    const result = await connection.executeIterator(`SELECT CAST (${hugeInt} AS HUGEINT)`, {
+      rowResultFormat: RowResultFormat.Array,
+    });
+    const resultValue = (<number[]>result.fetchRow())[0];
+    expect(resultValue).toEqual(hugeInt);
+  });
+
+  // TODO: possibly return as BigInt (napi v5+)
   it("supports HUGEINT", async () => {
-    const hugeInt = "-170141183460469231731687303715884105727";
+    const hugeInt = -170141183460469231731687303715884105727n;
     const result = await connection.executeIterator(`SELECT CAST (${hugeInt} AS HUGEINT)`, {
       rowResultFormat: RowResultFormat.Array,
     });

--- a/src/tests/data-types.test.ts
+++ b/src/tests/data-types.test.ts
@@ -1,4 +1,5 @@
 import { DuckDB, Connection, } from "@addon";
+import { RowResultFormat } from "@addon-types";
 
 describe("Data type mapping", () => {
     let db: DuckDB;
@@ -19,4 +20,28 @@ describe("Data type mapping", () => {
           );
           expect(result.fetchRow()).toMatchObject({"avg(deeprank)": 0.27228960482907333, "count(url)": 99729, "max(folder_count)": 12, "path1": "www.theverge.com", "sum(backlink_count)": null, "sum(links_in_count)": 7194376});
     })
+
+    it("char", async () => {
+      const result = await connection.executeIterator(
+        `SELECT 
+        CAST('a' AS CHAR)
+            `, { rowResultFormat: RowResultFormat.Array}
+      );
+  
+      expect(result.fetchRow()).toMatchObject(["a"]);
+    });
+
+
+  it.only("can read a single record containing all types", async () => {
+    const result = await connection.executeIterator(
+      `SELECT 
+            TIME '01:01:01.001'
+          `,
+          { rowResultFormat: RowResultFormat.Array},
+    );
+
+    expect(result.fetchRow()).toMatchObject([
+      1 + 1000 + 60000 + 60000 * 60,
+    ]);
+  });
 })

--- a/src/tests/data-types.test.ts
+++ b/src/tests/data-types.test.ts
@@ -25,21 +25,21 @@ describe("Data type mapping", () => {
   });
 
   it("supports TINYINT", async () => {
-    const result = await connection.executeIterator(`SELECT CAST(1 AS TINYINT)`, {
+    const result = await connection.executeIterator<number[]>(`SELECT CAST(1 AS TINYINT)`, {
       rowResultFormat: RowResultFormat.Array,
     });
     expect(result.fetchRow()).toMatchObject([1]);
   });
 
   it("supports SMALLINT", async () => {
-    const result = await connection.executeIterator(`SELECT CAST(1 AS SMALLINT)`, {
+    const result = await connection.executeIterator<number[]>(`SELECT CAST(1 AS SMALLINT)`, {
       rowResultFormat: RowResultFormat.Array,
     });
     expect(result.fetchRow()).toMatchObject([1]);
   });
 
   it("supports INTEGER", async () => {
-    const result = await connection.executeIterator(`SELECT CAST(1 AS INTEGER)`, {
+    const result = await connection.executeIterator<number[]>(`SELECT CAST(1 AS INTEGER)`, {
       rowResultFormat: RowResultFormat.Array,
     });
     expect(result.fetchRow()).toMatchObject([1]);
@@ -47,69 +47,69 @@ describe("Data type mapping", () => {
 
   it("supports BIGINT", async () => {
     const bigInt = 9223372036854775807n;
-    const result = await connection.executeIterator(`SELECT CAST (${bigInt} AS BIGINT)`, {
+    const result = await connection.executeIterator<Array<bigint>>(`SELECT CAST (${bigInt} AS BIGINT)`, {
       rowResultFormat: RowResultFormat.Array,
     });
-    const resultValue = result.fetchRow<number[]>()[0];
+    const resultValue = result.fetchRow()[0];
     expect(resultValue).toEqual(bigInt);
   });
 
   it("supports HUGEINT - positive max", async () => {
     const hugeInt = 170141183460469231731687303715884105727n;
-    const result = await connection.executeIterator(`SELECT CAST (${hugeInt} AS HUGEINT)`, {
+    const result = await connection.executeIterator<Array<bigint>>(`SELECT CAST (${hugeInt} AS HUGEINT)`, {
       rowResultFormat: RowResultFormat.Array,
     });
-    const resultValue = result.fetchRow<number[]>()[0];
+    const resultValue = result.fetchRow()[0];
     expect(resultValue).toEqual(hugeInt);
   });
 
   it("supports HUGEINT - large negative", async () => {
     const hugeInt = -4565365654654345325455654365n;
-    const result = await connection.executeIterator(`SELECT CAST (${hugeInt} AS HUGEINT)`, {
+    const result = await connection.executeIterator<Array<bigint>>(`SELECT CAST (${hugeInt} AS HUGEINT)`, {
       rowResultFormat: RowResultFormat.Array,
     });
-    const resultValue = result.fetchRow<number[]>()[0];
+    const resultValue = result.fetchRow()[0];
     expect(resultValue).toEqual(hugeInt);
   });
 
   it("supports HUGEINT - small positive number", async () => {
     const hugeInt = 132142n;
-    const result = await connection.executeIterator(`SELECT CAST (${hugeInt} AS HUGEINT)`, {
+    const result = await connection.executeIterator<Array<bigint>>(`SELECT CAST (${hugeInt} AS HUGEINT)`, {
       rowResultFormat: RowResultFormat.Array,
     });
-    const resultValue = result.fetchRow<number[]>()[0];
+    const resultValue = result.fetchRow()[0];
     expect(resultValue).toEqual(hugeInt);
   });
 
   it("supports HUGEINT - negative 1", async () => {
     const hugeInt = -1n;
-    const result = await connection.executeIterator(`SELECT CAST (${hugeInt} AS HUGEINT)`, {
+    const result = await connection.executeIterator<Array<bigint>>(`SELECT CAST (${hugeInt} AS HUGEINT)`, {
       rowResultFormat: RowResultFormat.Array,
     });
-    const resultValue = result.fetchRow<number[]>()[0];
+    const resultValue = result.fetchRow()[0];
     expect(resultValue).toEqual(hugeInt);
   });
 
   it("supports HUGEINT - large negative number", async () => {
     const hugeInt = -354235423543264236543654n;
-    const result = await connection.executeIterator(`SELECT CAST (${hugeInt} AS HUGEINT)`, {
+    const result = await connection.executeIterator<Array<bigint>>(`SELECT CAST (${hugeInt} AS HUGEINT)`, {
       rowResultFormat: RowResultFormat.Array,
     });
-    const resultValue = result.fetchRow<number[]>()[0];
+    const resultValue = result.fetchRow()[0];
     expect(resultValue).toEqual(hugeInt);
   });
 
   it("supports HUGEINT - negative max", async () => {
     const hugeInt = -170141183460469231731687303715884105727n;
-    const result = await connection.executeIterator(`SELECT CAST (${hugeInt} AS HUGEINT)`, {
+    const result = await connection.executeIterator<Array<bigint>>(`SELECT CAST (${hugeInt} AS HUGEINT)`, {
       rowResultFormat: RowResultFormat.Array,
     });
-    const resultValue = result.fetchRow<number[]>()[0];
+    const resultValue = result.fetchRow()[0];
     expect(resultValue).toEqual(hugeInt);
   });
 
   it("supports common types", async () => {
-    const result = await connection.executeIterator(
+    const result = await connection.executeIterator<any[]>(
       `SELECT 
               null,
               true,
@@ -143,24 +143,24 @@ describe("Data type mapping", () => {
 
   // Note: even though there is a CHAR type in the source code, it is simply an alias to VARCHAR
   it("supports CHAR", async () => {
-    const result = await connection.executeIterator(`SELECT CAST('a' AS CHAR)`, {
+    const result = await connection.executeIterator<string[]>(`SELECT CAST('a' AS CHAR)`, {
       rowResultFormat: RowResultFormat.Array,
     });
     expect(result.fetchRow()).toMatchObject(["a"]);
   });
 
   it("supports TIME", async () => {
-    const result = await connection.executeIterator(`SELECT TIME '01:01:01.001'`, {
+    const result = await connection.executeIterator<number[]>(`SELECT TIME '01:01:01.001'`, {
       rowResultFormat: RowResultFormat.Array,
     });
     expect(result.fetchRow()).toMatchObject([1 + 1000 + 60000 + 60000 * 60]);
   });
 
   it("supports BLOB", async () => {
-    const result = await connection.executeIterator(`SELECT 'AB'::BLOB;`, {
+    const result = await connection.executeIterator<Buffer[]>(`SELECT 'AB'::BLOB;`, {
       rowResultFormat: RowResultFormat.Array,
     });
-    const resultBuffer = result.fetchRow<Buffer[]>()[0];
+    const resultBuffer = result.fetchRow()[0];
     const view = new Int8Array(resultBuffer);
     // ASCII "a"
     expect(view[0]).toBe(65);
@@ -170,7 +170,7 @@ describe("Data type mapping", () => {
 
   // TODO: either create a JS/TS object representing an interval or possibly convert to number
   it("supports INTERVAL", async () => {
-    const result = await connection.executeIterator(`SELECT INTERVAL '1' MONTH;`, {
+    const result = await connection.executeIterator<string[]>(`SELECT INTERVAL '1' MONTH;`, {
       rowResultFormat: RowResultFormat.Array,
     });
     expect(result.fetchRow()).toMatchObject(["1 month"]);

--- a/src/tests/data-types.test.ts
+++ b/src/tests/data-types.test.ts
@@ -45,20 +45,18 @@ describe("Data type mapping", () => {
     expect(result.fetchRow()).toMatchObject([1]);
   });
 
-  // TODO: return as BigInt (napi v5+)
+  // TODO: possibly return as BigInt (napi v5+)
   it("supports BIGINT", async () => {
-    // FIXME: this is supposed to work, but getting some rounding bug -- probably JS Number issue (uses double under the hood)
-    // const bigInt = "9223372036854775807";
-    const bigInt = "-922337203685477";
+    const bigInt = "9223372036854775807";
 
     const result = await connection.executeIterator(`SELECT CAST (${bigInt} AS BIGINT)`, {
       rowResultFormat: RowResultFormat.Array,
     });
     const resultValue = (<number[]>result.fetchRow())[0];
-    expect(resultValue.toString()).toEqual(bigInt);
+    expect(resultValue).toEqual(bigInt);
   });
 
-  // TODO: return as BigInt (napi v5+)
+  // TODO: possibly return as BigInt (napi v5+)
   it("supports HUGEINT", async () => {
     const hugeInt = "-170141183460469231731687303715884105727";
     const result = await connection.executeIterator(`SELECT CAST (${hugeInt} AS HUGEINT)`, {
@@ -77,7 +75,6 @@ describe("Data type mapping", () => {
               CAST(1 AS TINYINT),
               CAST(8 AS SMALLINT),
               10000,
-              9223372036854775807,
               1.1,        
               CAST(1.1 AS DOUBLE),
               'stringy',
@@ -94,7 +91,6 @@ describe("Data type mapping", () => {
       1,
       8,
       10000,
-      9223372036854776000, // Note: not a BigInt (yet)
       1.1,
       1.1,
       "stringy",

--- a/src/tests/data-types.test.ts
+++ b/src/tests/data-types.test.ts
@@ -83,7 +83,7 @@ describe("Data type mapping", () => {
 
 
 
-  it.only("BLOB", async () => {
+  it("BLOB", async () => {
     const result = await connection.executeIterator(
       `SELECT  CAST('\\x3131' AS BLOB)
       
@@ -91,5 +91,15 @@ describe("Data type mapping", () => {
     );
 
     expect(result.fetchRow()).toMatchObject(["\\x3131"]);
+  });
+
+  // TODO: either create a JS/TS object representing an interval or possibly convert to number
+  it.only("interval", async () => {
+    const result = await connection.executeIterator(
+      `SELECT INTERVAL '1' MONTH;
+          `, { rowResultFormat: RowResultFormat.Array}
+    );
+
+    expect(result.fetchRow()).toMatchObject(["1 month"]);
   });
 })

--- a/src/tests/data-types.test.ts
+++ b/src/tests/data-types.test.ts
@@ -1,0 +1,22 @@
+import { DuckDB, Connection, } from "@addon";
+
+describe("Data type mapping", () => {
+    let db: DuckDB;
+    let connection: Connection;
+    beforeEach(() => {
+      db = new DuckDB();
+      connection = new Connection(db);
+    });
+  
+    afterEach(() => {
+      connection.close();
+      db.close();
+    });
+  
+    it("correctly resolves HUGEINT", async () => {
+        const result = await connection.executeIterator(
+            `SELECT path1, count(url), avg(deeprank), sum(links_in_count), sum(backlink_count), max(folder_count) FROM parquet_scan('crawl_urls.parquet') WHERE ((url <> '' AND url IS NOT NULL) AND ((css <> TRUE OR css IS NULL) AND (js <> TRUE OR js IS NULL) AND (is_image <> TRUE OR is_image IS NULL) AND internal = TRUE)) GROUP BY path1 ORDER BY count(url) DESC LIMIT 10`,
+          );
+          expect(result.fetchRow()).toMatchObject({"avg(deeprank)": 0.27228960482907333, "count(url)": 99729, "max(folder_count)": 12, "path1": "www.theverge.com", "sum(backlink_count)": null, "sum(links_in_count)": 7194376});
+    })
+})

--- a/src/tests/data-types.test.ts
+++ b/src/tests/data-types.test.ts
@@ -99,7 +99,7 @@ describe("Data type mapping", () => {
     ]);
   });
 
-  // Note: even though there is a CHAR type in the source code, seems to be an alias to VARCHAR
+  // Note: even though there is a CHAR type in the source code, it is simply an alias to VARCHAR
   it("supports CHAR", async () => {
     const result = await connection.executeIterator(`SELECT CAST('a' AS CHAR)`, {
       rowResultFormat: RowResultFormat.Array,

--- a/src/tests/data-types.test.ts
+++ b/src/tests/data-types.test.ts
@@ -45,44 +45,66 @@ describe("Data type mapping", () => {
     expect(result.fetchRow()).toMatchObject([1]);
   });
 
-  // TODO: possibly return as BigInt (napi v5+)
   it("supports BIGINT", async () => {
     const bigInt = 9223372036854775807n;
-
     const result = await connection.executeIterator(`SELECT CAST (${bigInt} AS BIGINT)`, {
       rowResultFormat: RowResultFormat.Array,
     });
-    const resultValue = (<number[]>result.fetchRow())[0];
+    const resultValue = result.fetchRow<number[]>()[0];
     expect(resultValue).toEqual(bigInt);
   });
 
-  // TODO: possibly return as BigInt (napi v5+)
-  it.only("supports HUGEINT - positive max", async () => {
+  it("supports HUGEINT - positive max", async () => {
     const hugeInt = 170141183460469231731687303715884105727n;
     const result = await connection.executeIterator(`SELECT CAST (${hugeInt} AS HUGEINT)`, {
       rowResultFormat: RowResultFormat.Array,
     });
-    const resultValue = (<number[]>result.fetchRow())[0];
+    const resultValue = result.fetchRow<number[]>()[0];
     expect(resultValue).toEqual(hugeInt);
   });
 
-  // TODO: possibly return as BigInt (napi v5+)
-  it("supports HUGEINT - regular number", async () => {
+  it("supports HUGEINT - large negative", async () => {
+    const hugeInt = -4565365654654345325455654365n;
+    const result = await connection.executeIterator(`SELECT CAST (${hugeInt} AS HUGEINT)`, {
+      rowResultFormat: RowResultFormat.Array,
+    });
+    const resultValue = result.fetchRow<number[]>()[0];
+    expect(resultValue).toEqual(hugeInt);
+  });
+
+  it("supports HUGEINT - small positive number", async () => {
     const hugeInt = 132142n;
     const result = await connection.executeIterator(`SELECT CAST (${hugeInt} AS HUGEINT)`, {
       rowResultFormat: RowResultFormat.Array,
     });
-    const resultValue = (<number[]>result.fetchRow())[0];
+    const resultValue = result.fetchRow<number[]>()[0];
     expect(resultValue).toEqual(hugeInt);
   });
 
-  // TODO: possibly return as BigInt (napi v5+)
-  it("supports HUGEINT", async () => {
+  it("supports HUGEINT - negative 1", async () => {
+    const hugeInt = -1n;
+    const result = await connection.executeIterator(`SELECT CAST (${hugeInt} AS HUGEINT)`, {
+      rowResultFormat: RowResultFormat.Array,
+    });
+    const resultValue = result.fetchRow<number[]>()[0];
+    expect(resultValue).toEqual(hugeInt);
+  });
+
+  it("supports HUGEINT - large negative number", async () => {
+    const hugeInt = -354235423543264236543654n;
+    const result = await connection.executeIterator(`SELECT CAST (${hugeInt} AS HUGEINT)`, {
+      rowResultFormat: RowResultFormat.Array,
+    });
+    const resultValue = result.fetchRow<number[]>()[0];
+    expect(resultValue).toEqual(hugeInt);
+  });
+
+  it("supports HUGEINT - negative max", async () => {
     const hugeInt = -170141183460469231731687303715884105727n;
     const result = await connection.executeIterator(`SELECT CAST (${hugeInt} AS HUGEINT)`, {
       rowResultFormat: RowResultFormat.Array,
     });
-    const resultValue = (<number[]>result.fetchRow())[0];
+    const resultValue = result.fetchRow<number[]>()[0];
     expect(resultValue).toEqual(hugeInt);
   });
 

--- a/src/tests/fetch-all-rows.test.ts
+++ b/src/tests/fetch-all-rows.test.ts
@@ -1,7 +1,7 @@
 import { Connection, DuckDB } from "@addon";
 
 const jsonResult = {
-  bigint_col: "0",
+  bigint_col: 0n,
   bool_col: true,
   date_string_col: "03/01/09",
   double_col: 0,

--- a/src/tests/fetch-all-rows.test.ts
+++ b/src/tests/fetch-all-rows.test.ts
@@ -1,7 +1,7 @@
 import { Connection, DuckDB } from "@addon";
 
 const jsonResult = {
-  bigint_col: 0,
+  bigint_col: "0",
   bool_col: true,
   date_string_col: "03/01/09",
   double_col: 0,

--- a/src/tests/force-materialized-switch.test.ts
+++ b/src/tests/force-materialized-switch.test.ts
@@ -21,12 +21,12 @@ describe("Streaming/materialized capability", () => {
       rowResultFormat: RowResultFormat.Array,
       forceMaterialized: false,
     });
-    expect(result.fetchRow()).toMatchObject(["60"]);
+    expect(result.fetchRow()).toMatchObject([60n]);
     expect(result.type).toBe(ResultType.Streaming);
   });
   it("streams by default", async () => {
     const result = await connection.executeIterator(query, { rowResultFormat: RowResultFormat.Array });
-    expect(result.fetchRow()).toMatchObject(["60"]);
+    expect(result.fetchRow()).toMatchObject([60n]);
     expect(result.type).toBe(ResultType.Streaming);
   });
   it("allows materialized", async () => {
@@ -34,7 +34,7 @@ describe("Streaming/materialized capability", () => {
       rowResultFormat: RowResultFormat.Array,
       forceMaterialized: true,
     });
-    expect(result.fetchRow()).toMatchObject(["60"]);
+    expect(result.fetchRow()).toMatchObject([60n]);
     expect(result.type).toBe(ResultType.Materialized);
   });
   it("validates type parameter", async () => {

--- a/src/tests/force-materialized-switch.test.ts
+++ b/src/tests/force-materialized-switch.test.ts
@@ -21,12 +21,12 @@ describe("Streaming/materialized capability", () => {
       rowResultFormat: RowResultFormat.Array,
       forceMaterialized: false,
     });
-    expect(result.fetchRow()).toMatchObject([60]);
+    expect(result.fetchRow()).toMatchObject(["60"]);
     expect(result.type).toBe(ResultType.Streaming);
   });
   it("streams by default", async () => {
     const result = await connection.executeIterator(query, { rowResultFormat: RowResultFormat.Array });
-    expect(result.fetchRow()).toMatchObject([60]);
+    expect(result.fetchRow()).toMatchObject(["60"]);
     expect(result.type).toBe(ResultType.Streaming);
   });
   it("allows materialized", async () => {
@@ -34,7 +34,7 @@ describe("Streaming/materialized capability", () => {
       rowResultFormat: RowResultFormat.Array,
       forceMaterialized: true,
     });
-    expect(result.fetchRow()).toMatchObject([60]);
+    expect(result.fetchRow()).toMatchObject(["60"]);
     expect(result.type).toBe(ResultType.Materialized);
   });
   it("validates type parameter", async () => {

--- a/src/tests/parquet.test.ts
+++ b/src/tests/parquet.test.ts
@@ -21,7 +21,7 @@ describe("executeIterator on parquet", () => {
       "SELECT count(*) FROM parquet_scan('src/tests/test-fixtures/alltypes_plain.parquet')",
       executeOptions,
     );
-    expect(result.fetchRow()).toMatchObject(["8"]);
+    expect(result.fetchRow()).toMatchObject([8n]);
     expect(result.fetchRow()).toBe(null);
   });
 
@@ -30,14 +30,14 @@ describe("executeIterator on parquet", () => {
       "SELECT * FROM parquet_scan('src/tests/test-fixtures/alltypes_plain.parquet')",
       executeOptions,
     );
-    expect(result.fetchRow()).toMatchObject([4, true, 0, 0, 0, "0", 0, 0, "03/01/09", "0", 1235865600000]);
+    expect(result.fetchRow()).toMatchObject([4, true, 0, 0, 0, 0n, 0, 0, "03/01/09", "0", 1235865600000]);
     expect(result.fetchRow()).toMatchObject([
       5,
       false,
       1,
       1,
       1,
-      "10",
+      10n,
       1.100000023841858,
       10.1,
       "03/01/09",

--- a/src/tests/parquet.test.ts
+++ b/src/tests/parquet.test.ts
@@ -21,7 +21,7 @@ describe("executeIterator on parquet", () => {
       "SELECT count(*) FROM parquet_scan('src/tests/test-fixtures/alltypes_plain.parquet')",
       executeOptions,
     );
-    expect(result.fetchRow()).toMatchObject([8]);
+    expect(result.fetchRow()).toMatchObject(["8"]);
     expect(result.fetchRow()).toBe(null);
   });
 
@@ -30,14 +30,14 @@ describe("executeIterator on parquet", () => {
       "SELECT * FROM parquet_scan('src/tests/test-fixtures/alltypes_plain.parquet')",
       executeOptions,
     );
-    expect(result.fetchRow()).toMatchObject([4, true, 0, 0, 0, 0, 0, 0, "03/01/09", "0", 1235865600000]);
+    expect(result.fetchRow()).toMatchObject([4, true, 0, 0, 0, "0", 0, 0, "03/01/09", "0", 1235865600000]);
     expect(result.fetchRow()).toMatchObject([
       5,
       false,
       1,
       1,
       1,
-      10,
+      "10",
       1.100000023841858,
       10.1,
       "03/01/09",

--- a/src/tests/result-format.test.ts
+++ b/src/tests/result-format.test.ts
@@ -3,7 +3,7 @@ import { RowResultFormat } from "@addon-types";
 
 const query = "SELECT * FROM parquet_scan('src/tests/test-fixtures/alltypes_plain.parquet')";
 const jsonResult = {
-  bigint_col: "0",
+  bigint_col: 0n,
   bool_col: true,
   date_string_col: "03/01/09",
   double_col: 0,
@@ -16,7 +16,7 @@ const jsonResult = {
   tinyint_col: 0,
 };
 
-const arrayResult = [4, true, 0, 0, 0, "0", 0, 0, "03/01/09", "0", 1235865600000];
+const arrayResult = [4, true, 0, 0, 0, 0n, 0, 0, "03/01/09", "0", 1235865600000];
 describe("Result format", () => {
   let db: DuckDB;
   let connection: Connection;

--- a/src/tests/result-format.test.ts
+++ b/src/tests/result-format.test.ts
@@ -3,7 +3,7 @@ import { RowResultFormat } from "@addon-types";
 
 const query = "SELECT * FROM parquet_scan('src/tests/test-fixtures/alltypes_plain.parquet')";
 const jsonResult = {
-  bigint_col: 0,
+  bigint_col: "0",
   bool_col: true,
   date_string_col: "03/01/09",
   double_col: 0,
@@ -16,7 +16,7 @@ const jsonResult = {
   tinyint_col: 0,
 };
 
-const arrayResult = [4, true, 0, 0, 0, 0, 0, 0, "03/01/09", "0", 1235865600000];
+const arrayResult = [4, true, 0, 0, 0, "0", 0, 0, "03/01/09", "0", 1235865600000];
 describe("Result format", () => {
   let db: DuckDB;
   let connection: Connection;

--- a/src/tests/result-iterator-materialized.test.ts
+++ b/src/tests/result-iterator-materialized.test.ts
@@ -16,42 +16,12 @@ describe("Result iterator (materialized)", () => {
     db.close();
   });
 
-  it("can read a single record containing all types except TIME", async () => {
-    const result = await connection.executeIterator(
-      `SELECT 
-            null,
-            true,
-            0,
-            CAST(1 AS TINYINT),
-            CAST(8 AS SMALLINT),
-            10000,
-            9223372036854775807,
-            1.1,        
-            CAST(1.1 AS DOUBLE),
-            'stringy',
-            TIMESTAMP '1971-02-02 01:01:01.001',
-            DATE '1971-02-02'
-          `,
-      executeOptions,
-    );
+  it("can read a meterialized result", async () => {
+    const result = await connection.executeIterator(`SELECT null`, executeOptions);
     expect(result.type).toBe(ResultType.Materialized);
 
-    expect(result.fetchRow()).toMatchObject([
-      null,
-      true,
-      0,
-      1,
-      8,
-      10000,
-      9223372036854776000, // Note: not a BigInt (yet)
-      1.1,
-      1.1,
-      "stringy",
-      Date.UTC(71, 1, 2, 1, 1, 1, 1),
-      Date.UTC(71, 1, 2),
-    ]);
+    expect(result.fetchRow()).toMatchObject([null]);
   });
-
 
   it("is able to close - throws error when reading from closed result", async () => {
     const result1 = await connection.executeIterator(

--- a/src/tests/result-iterator-materialized.test.ts
+++ b/src/tests/result-iterator-materialized.test.ts
@@ -52,45 +52,6 @@ describe("Result iterator (materialized)", () => {
     ]);
   });
 
-  // TODO: enable (duckdb v0.22 broke the TIME type) and remove the test above
-  // eslint-disable-next-line jest/no-disabled-tests
-  it.skip("can read a single record containing all types", async () => {
-    const result = await connection.executeIterator(
-      `SELECT 
-            null,
-            true,
-            0,
-            CAST(1 AS TINYINT),
-            CAST(8 AS SMALLINT),
-            10000,
-            9223372036854775807,
-            1.1,        
-            CAST(1.1 AS DOUBLE),
-            'stringy',
-            TIMESTAMP '1971-02-02 01:01:01.001',
-            DATE '1971-02-02',
-            TIME '01:01:01.001'
-          `,
-      executeOptions,
-    );
-    expect(result.type).toBe(ResultType.Materialized);
-
-    expect(result.fetchRow()).toMatchObject([
-      null,
-      true,
-      0,
-      1,
-      8,
-      10000,
-      9223372036854776000, // Note: not a BigInt (yet)
-      1.1,
-      1.1,
-      "stringy",
-      Date.UTC(71, 1, 2, 1, 1, 1, 1),
-      Date.UTC(71, 1, 2),
-      1 + 1000 + 60000 + 60000 * 60,
-    ]);
-  });
 
   it("is able to close - throws error when reading from closed result", async () => {
     const result1 = await connection.executeIterator(

--- a/src/tests/result-iterator-streaming.test.ts
+++ b/src/tests/result-iterator-streaming.test.ts
@@ -25,7 +25,7 @@ describe("Result iterator (streaming)", () => {
     expect(() => result1.fetchRow()).toThrow(
       "No data has been returned (possibly stream has been closed: only one stream can be active on one connection at a time)",
     );
-    expect(result2.fetchRow()).toEqual([60]);
+    expect(result2.fetchRow()).toEqual(["60"]);
   });
 
   it("gracefully handles inactive stream - second query is materialized", async () => {
@@ -38,14 +38,14 @@ describe("Result iterator (streaming)", () => {
     expect(() => result1.fetchRow()).toThrow(
       "No data has been returned (possibly stream has been closed: only one stream can be active on one connection at a time)",
     );
-    expect(result2.fetchRow()).toEqual([60]);
+    expect(result2.fetchRow()).toEqual(["60"]);
   });
 
   it("works fine if done one after another", async () => {
     const result1 = await connection.executeIterator(query, executeOptions);
-    expect(result1.fetchRow()).toEqual([60]);
+    expect(result1.fetchRow()).toEqual(["60"]);
     const result2 = await connection.executeIterator(query, executeOptions);
-    expect(result2.fetchRow()).toEqual([60]);
+    expect(result2.fetchRow()).toEqual(["60"]);
   });
 
   it("is able to close - throws error when reading from closed result", async () => {
@@ -63,8 +63,8 @@ describe("Result iterator (streaming)", () => {
     const connection2 = new Connection(db);
     const result1 = await connection1.executeIterator(query, executeOptions);
     const result2 = await connection2.executeIterator(query, executeOptions);
-    expect(result1.fetchRow()).toEqual([60]);
-    expect(result2.fetchRow()).toEqual([60]);
+    expect(result1.fetchRow()).toEqual(["60"]);
+    expect(result2.fetchRow()).toEqual(["60"]);
   });
 
   it("works fine if two streaming operations are done on separate databases", async () => {

--- a/src/tests/result-iterator-streaming.test.ts
+++ b/src/tests/result-iterator-streaming.test.ts
@@ -25,7 +25,7 @@ describe("Result iterator (streaming)", () => {
     expect(() => result1.fetchRow()).toThrow(
       "No data has been returned (possibly stream has been closed: only one stream can be active on one connection at a time)",
     );
-    expect(result2.fetchRow()).toEqual(["60"]);
+    expect(result2.fetchRow()).toEqual([60n]);
   });
 
   it("gracefully handles inactive stream - second query is materialized", async () => {
@@ -38,14 +38,14 @@ describe("Result iterator (streaming)", () => {
     expect(() => result1.fetchRow()).toThrow(
       "No data has been returned (possibly stream has been closed: only one stream can be active on one connection at a time)",
     );
-    expect(result2.fetchRow()).toEqual(["60"]);
+    expect(result2.fetchRow()).toEqual([60n]);
   });
 
   it("works fine if done one after another", async () => {
     const result1 = await connection.executeIterator(query, executeOptions);
-    expect(result1.fetchRow()).toEqual(["60"]);
+    expect(result1.fetchRow()).toEqual([60n]);
     const result2 = await connection.executeIterator(query, executeOptions);
-    expect(result2.fetchRow()).toEqual(["60"]);
+    expect(result2.fetchRow()).toEqual([60n]);
   });
 
   it("is able to close - throws error when reading from closed result", async () => {
@@ -63,8 +63,8 @@ describe("Result iterator (streaming)", () => {
     const connection2 = new Connection(db);
     const result1 = await connection1.executeIterator(query, executeOptions);
     const result2 = await connection2.executeIterator(query, executeOptions);
-    expect(result1.fetchRow()).toEqual(["60"]);
-    expect(result2.fetchRow()).toEqual(["60"]);
+    expect(result1.fetchRow()).toEqual([60n]);
+    expect(result2.fetchRow()).toEqual([60n]);
   });
 
   it("works fine if two streaming operations are done on separate databases", async () => {

--- a/src/tests/result-stream.test.ts
+++ b/src/tests/result-stream.test.ts
@@ -5,9 +5,9 @@ const query = "SELECT * FROM read_csv_auto('src/tests/test-fixtures/web_page.csv
 
 const executeOptions: IExecuteOptions = { rowResultFormat: RowResultFormat.Array };
 
-function readStream(rs: ResultStream): Promise<any[]> {
+function readStream<T>(rs: ResultStream<T>): Promise<T[]> {
   return new Promise((resolve, reject) => {
-    const elements: any[] = [];
+    const elements: T[] = [];
     rs.on("data", (el: any) => elements.push(el));
     rs.on("error", reject);
     rs.on("end", () => resolve(elements));

--- a/src/tests/result-stream.test.ts
+++ b/src/tests/result-stream.test.ts
@@ -112,6 +112,6 @@ describe("Result stream", () => {
     const p = connection.execute(query2, executeOptions);
     connection.close();
     const elements = await readStream(await p);
-    expect(elements).toEqual([["15000"]]);
+    expect(elements).toEqual([[15000n]]);
   });
 });

--- a/src/tests/result-stream.test.ts
+++ b/src/tests/result-stream.test.ts
@@ -112,6 +112,6 @@ describe("Result stream", () => {
     const p = connection.execute(query2, executeOptions);
     connection.close();
     const elements = await readStream(await p);
-    expect(elements).toEqual([[15000]]);
+    expect(elements).toEqual([["15000"]]);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,9 +13,9 @@
 
       /* Basic Options */
       "incremental": false,                     /* Enable incremental compilation */
-      "target": "es2019",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+      "target": "es2020",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
       "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-      "lib": ["es2019"],                        /* Specify library files to be included in the compilation. */
+      "lib": ["es2020"],                        /* Specify library files to be included in the compilation. */
       "declaration": true,                      /* Generates corresponding '.d.ts' file. */
       "declarationMap": true   ,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
       "composite": false,                       /* Enable project compilation */


### PR DESCRIPTION
What's in this PR:
- TIME type supported
- BigInt returned as BigInt
- HugeInt supported and returned as BigInt
- Blob is returned as a Buffer
- Interval is supported, returned as string for now. Should probably be a number or an custom type object (need to dig deeper into duckdb source for this). Again, not a use case for DC ATM AFAIK
- any unhandled/unknown types are now returned as a string:
   - there are a bunch of other types in the source code for which there is no documentation and I don't know if they can ever be returned in a result set (and how) 
