### PR TITLE
[ODIN-378] close() bugfix

### DIFF
--- a/addon/async_executor.cc
+++ b/addon/async_executor.cc
@@ -8,7 +8,7 @@
 using namespace duckdb;
 
 namespace NodeDuckDB {
-    AsyncExecutor::AsyncExecutor(Napi::Env &env, std::string &query, std::shared_ptr<duckdb::Connection> &connection, Napi::Promise::Deferred &deferred, bool forceMaterialized, ResultFormat &rowResultFormat) : Napi::AsyncWorker(env), query(query), connection(connection), deferred(deferred), forceMaterialized(forceMaterialized), rowResultFormat(rowResultFormat) {}
+    AsyncExecutor::AsyncExecutor(Napi::Env &env, std::string &query, std::shared_ptr<duckdb::Connection> &connection, Napi::Promise::Deferred &deferred, bool forceMaterialized, ResultFormat &rowResultFormat, std::shared_ptr<std::vector<ResultIterator*>> results) : Napi::AsyncWorker(env), query(query), connection(connection), deferred(deferred), forceMaterialized(forceMaterialized), rowResultFormat(rowResultFormat), results(std::move(results)) {}
 
     AsyncExecutor::~AsyncExecutor() {}
 
@@ -39,6 +39,7 @@ namespace NodeDuckDB {
         ResultIterator *result_unwrapped = ResultIterator::Unwrap(result_iterator);
         result_unwrapped->result = std::move(result);
         result_unwrapped->rowResultFormat = rowResultFormat;
+        results->push_back(result_unwrapped);
         deferred.Resolve(result_iterator);
     }
 

--- a/addon/async_executor.h
+++ b/addon/async_executor.h
@@ -3,13 +3,14 @@
 #include "result_iterator.h"
 #include <string>
 #include "result_iterator.h"
+#include <memory>
 
 
 namespace NodeDuckDB {
     class AsyncExecutor : public Napi::AsyncWorker
     {
         public:
-            AsyncExecutor(Napi::Env &env, std::string &query, std::shared_ptr<duckdb::Connection> &connection, Napi::Promise::Deferred &deferred, bool forceMaterialized, ResultFormat &rowResultFormat);
+            AsyncExecutor(Napi::Env &env, std::string &query, std::shared_ptr<duckdb::Connection> &connection, Napi::Promise::Deferred &deferred, bool forceMaterialized, ResultFormat &rowResultFormat, std::shared_ptr<std::vector<ResultIterator*>> results);
             ~AsyncExecutor();
             void Execute() override;
             void OnOK() override;
@@ -20,6 +21,7 @@ namespace NodeDuckDB {
             ResultFormat rowResultFormat;
             std::shared_ptr<duckdb::Connection> connection;
             std::unique_ptr<duckdb::QueryResult> result;
+            std::shared_ptr<std::vector<ResultIterator*>> results;
             Napi::Promise::Deferred deferred;
             bool forceMaterialized;
     };

--- a/addon/connection.h
+++ b/addon/connection.h
@@ -3,6 +3,8 @@
 
 #include <napi.h>
 #include "duckdb.hpp"
+#include <vector>
+#include "result_iterator.h"
 
 namespace NodeDuckDB {
   class Connection : public Napi::ObjectWrap<Connection> {
@@ -18,6 +20,7 @@ namespace NodeDuckDB {
 
       shared_ptr<duckdb::DuckDB> database;
       shared_ptr<duckdb::Connection> connection;
+      std::shared_ptr<std::vector<ResultIterator*>> results;
   };
 }
 #endif

--- a/addon/duckdb.cc
+++ b/addon/duckdb.cc
@@ -62,7 +62,7 @@ namespace NodeDuckDB {
   }
 
   Napi::Value DuckDB::Close(const Napi::CallbackInfo& info) {
-    database = nullptr;
+    database.reset();
     return info.Env().Undefined();
   }
   Napi::Value DuckDB::IsClosed(const Napi::CallbackInfo &info) {

--- a/addon/result_iterator.cc
+++ b/addon/result_iterator.cc
@@ -204,4 +204,8 @@ namespace NodeDuckDB {
         return Napi::String::New(env, val.ToString());
       }
   }
+  Napi::Value ResultIterator::Close(const Napi::CallbackInfo &info) {
+    result = nullptr;
+    return info.Env().Undefined();
+  }
 }

--- a/addon/result_iterator.cc
+++ b/addon/result_iterator.cc
@@ -205,7 +205,10 @@ namespace NodeDuckDB {
       }
   }
   Napi::Value ResultIterator::Close(const Napi::CallbackInfo &info) {
-    result = nullptr;
+    result.reset();
     return info.Env().Undefined();
+  }
+  void ResultIterator::close() {
+    result.reset();
   }
 }

--- a/addon/result_iterator.h
+++ b/addon/result_iterator.h
@@ -14,6 +14,7 @@ namespace NodeDuckDB {
 			static Napi::Object Create();
 			unique_ptr<duckdb::QueryResult> result;
 			ResultFormat rowResultFormat;
+			void close();
 
 		private:
 			static Napi::FunctionReference constructor;

--- a/addon/result_iterator.h
+++ b/addon/result_iterator.h
@@ -20,10 +20,7 @@ namespace NodeDuckDB {
 			Napi::Value FetchRow(const Napi::CallbackInfo& info);
 			Napi::Value Describe(const Napi::CallbackInfo& info);
 			Napi::Value GetType(const Napi::CallbackInfo &info);
-			Napi::Value Close(const Napi::CallbackInfo &info) {
-				result = nullptr;
-				return info.Env().Undefined();
-			}
+			Napi::Value Close(const Napi::CallbackInfo &info);
 			Napi::Value IsClosed(const Napi::CallbackInfo &info);
 			unique_ptr<duckdb::DataChunk> current_chunk;
 			uint64_t chunk_offset = 0;

--- a/examples/package.json
+++ b/examples/package.json
@@ -8,7 +8,7 @@
     "run-stream-example": "node dist/stream-example.js"
   },
   "dependencies": {
-    "@deepcrawl/node-duckdb": "0.0.29",
+    "@deepcrawl/node-duckdb": "0.0.32",
     "@types/node": "^14.14.10",
     "typescript": "^4.1.2"
   }

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@deepcrawl/node-duckdb@0.0.29":
-  version "0.0.29"
-  resolved "https://npm.pkg.github.com/download/@deepcrawl/node-duckdb/0.0.29/40d89927314aca45d97a6f8e9466ced9bb840889678890524c56fb8df7c3f7d8#b770c5dca74caec0a56013ff13fb2b6f1c3dbcda"
-  integrity sha512-t5+5nKe7OmMav4HGuakiNrfslY5wnRVxnTe+aOEbUL259LpUTg+L84/cIz33PCf3yKTg3OCe/1ncFFy5uVtdfA==
+"@deepcrawl/node-duckdb@0.0.32":
+  version "0.0.32"
+  resolved "https://npm.pkg.github.com/download/@deepcrawl/node-duckdb/0.0.32/11ce6ffef2ddb3082d78985daadcddd77fd00b92c5179f0f48ff5df2e338ee20#35e9f1464e6731f7a59719f61875ebfd824374f6"
+  integrity sha512-D9C7y6pbdL1RR+EifZpIA4XU4LFfEI8bs6QZWThdtmRytR0XaE9DJIFbYanIfCK5DRv5zAIWgdWoCa/w1n01Ew==
   dependencies:
     cmake-js "^6.1.0"
     node-addon-api "^3.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deepcrawl/node-duckdb",
-  "version": "0.0.29",
+  "version": "0.0.32",
   "private": false,
   "repository": {
     "type": "git",


### PR DESCRIPTION
The bug:
```
import { Connection, DuckDB } from "@addon";
import { RowResultFormat } from "index";

async function queryDatabaseWithIterator() {
  const db = new DuckDB();
  const connection = new Connection(db);
  await connection.executeIterator("CREATE TABLE people(id INTEGER, name VARCHAR);");
  await connection.executeIterator("INSERT INTO people VALUES (1, 'Mark'), (2, 'Hannes'), (3, 'Bob');");
  const result = await connection.executeIterator("SELECT * FROM people;");
  console.log(result.fetchRow());
  console.log(result.fetchAllRows());
  const result2 = await connection.executeIterator("SELECT * FROM people;", {rowResultFormat: RowResultFormat.Array});
  console.log(result2.fetchAllRows());
  const result3 = await connection.executeIterator("SELECT * FROM people;", {rowResultFormat: RowResultFormat.Array});
  console.log(result3.fetchAllRows());
  connection.close();
  db.close(); 
}

queryDatabaseWithIterator();
```

- There is a destruction chain dependency between result iterators and their connections which manifests itself only sometimes. 
- If you do not call `close()` on neither the connection nor the database, GC destroys everything without any problems
- However, when you manually close either the connection or the database you get (in this particular case):
    - connection: a bad mutex error (when GC collects the object)
    - database: a segmentation error (when `close()` is called on the object)

 The solution is to close the iterators first and then their connection. 

  